### PR TITLE
ci(repo): add commitlint.config.ts and the pr-name and commitlint workflows, Node only on the CI runner

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,30 @@
+name: commitlint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # Advisory: branch commits are discarded by the squash merge, so this job is
+  # never a required check. It lints every commit the PR adds on top of its base
+  # branch with the same commitlint.config.ts as the pr-title job in pr-name.yml.
+  commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+      - name: Install commitlint (CI only, the repo has no package.json)
+        run: npm install --no-save --no-package-lock --no-audit --no-fund @commitlint/cli@21 @commitlint/config-conventional@21 @commitlint/types@21
+      # The base branch name goes through an environment variable, like the PR
+      # title in pr-name.yml, so nothing from the event is interpolated into the script.
+      - name: Lint the commit messages
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: npx --no-install commitlint --config commitlint.config.ts --from "origin/$BASE_REF" --to HEAD --verbose

--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -1,0 +1,32 @@
+name: pr-name-linter
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  # PRs are squash-merged, so the PR title becomes the commit header on main and
+  # the line release-please writes in CHANGELOG.md. The main ruleset requires
+  # this check by its context, which is the job id: do not rename it.
+  pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+      # Node is not part of the checkout (no package.json): install commitlint
+      # ad hoc, pinned to its major, and lint with the repo config file.
+      - name: Install commitlint (CI only, the repo has no package.json)
+        run: npm install --no-save --no-package-lock --no-audit --no-fund @commitlint/cli@21 @commitlint/config-conventional@21 @commitlint/types@21
+      # The title is attacker-controlled text on fork PRs: it goes through an
+      # environment variable and is never interpolated into the script.
+      - name: Lint the PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s\n' "$PR_TITLE" | npx --no-install commitlint --config commitlint.config.ts --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ tools/*.blend
 tools/*.blend?
 *.blend1
 *.blend2
+
+# commitlint run locally with the same npm command as CI
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ Agents get scene tools (summary, object detail, select, set frame, screenshots, 
 
 Credits spent on this project so far: about 207 CU (185 CU of probes and smokes, plus two accidental 11 CU GPT Image 2 jobs on 2026-08-28 triggered by keyboard focus landing in an automated GUI test window; the screenshot tool now disables Generate) (two Patina probes 12 CU, Gemini smoke 9 CU, Patina smoke 6 CU, Seedance smoke 76 CU plus one failed 76 CU attempt on a 0.5 s clip, quality-gate fees), cap agreed about $30.
 
+## Commit messages and PR titles
+
+Every change lands by a squash-merged pull request, so the PR title becomes the commit header on `main`. Titles and commit messages follow [Conventional Commits](https://www.conventionalcommits.org): `type(scope): summary`, imperative, at most 120 characters, no em dashes. `commitlint.config.ts` is the single source of truth (types from `@commitlint/config-conventional`, the scope list, the no-em-dash rule). CI lints the PR title with it (`pr-title`, in `.github/workflows/pr-name.yml`) and the branch commits (`commits`, in `.github/workflows/commitlint.yml`). Node is not part of the checkout; to run the same check locally:
+
+```
+npm install --no-save --no-package-lock --no-audit --no-fund @commitlint/cli@21 @commitlint/config-conventional@21 @commitlint/types@21
+printf '%s\n' "feat(ui): my title" | npx --no-install commitlint --config commitlint.config.ts --verbose
+```
+
 ## Verified vs assumed
 
 Verified live (2026-08-28): REST Basic auth, model records carry UI schema, `?dryRun=true` cost preview, Patina returns 6 typed map assets, multipart upload flow, GLB asset shape, Blender 5.1.1 Python 3.13.9 with gltf/fbx/obj importers and `render.opengl`, OAuth dynamic registration on mcp.scenario.com. Assumed: Patina smoothness semantics (pixels suggest dark = rough), normal-map convention, Blender 4.2/4.5 behaviour (only 5.1.1 installed here).

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,65 @@
+// Single source of truth for commit headers and PR titles.
+// Types come from @commitlint/config-conventional; the scope list below is the
+// one the contributor guide mirrors. Node is never part of the checkout: CI
+// installs commitlint ad hoc (see .github/workflows/pr-name.yml and
+// .github/workflows/commitlint.yml). To run the same check locally:
+//
+//   npm install --no-save --no-package-lock --no-audit --no-fund @commitlint/cli@21 @commitlint/config-conventional@21 @commitlint/types@21
+//   printf '%s\n' "feat(ui): my title" | npx --no-install commitlint --config commitlint.config.ts --verbose
+
+import type { Plugin, UserConfig } from "@commitlint/types";
+
+// U+2014 written as a code point so that this file contains no em dash itself.
+const EM_DASH = String.fromCharCode(0x2014);
+
+const houseRules: Plugin = {
+  rules: {
+    // House style: no em dashes anywhere, commit messages and PR titles included.
+    "no-em-dash": ({ raw }) => [
+      !(raw ?? "").includes(EM_DASH),
+      "no em dashes in commit messages or PR titles (house style, see CONTRIBUTING.md)",
+    ],
+  },
+};
+
+const config: UserConfig = {
+  extends: ["@commitlint/config-conventional"],
+  plugins: [houseRules],
+  rules: {
+    // Allow longer headers than the 100-character default (same as the sibling repos).
+    "header-max-length": [2, "always", 120],
+    // Off: long URLs and Co-Authored-By trailers exceed the 100-character default.
+    "body-max-line-length": [0, "always", 200],
+    "footer-max-line-length": [0, "always", 200],
+    // Off: Blender, Rodin, Patina, MCP and GLB start many subjects.
+    "subject-case": [0],
+    // Warn, never fail: the release-please PR is "chore: release X.Y.Z" with no scope.
+    "scope-empty": [1, "never"],
+    "scope-enum": [
+      2,
+      "always",
+      [
+        "core", // scenario/core cross-cutting: config.py, history.py
+        "api", // scenario/core/api: REST client, catalog, generate, jobs endpoints, llm, spark
+        "jobs", // scenario/core/jobs: manager, records
+        "scene", // scenario/core/scene: blockout, capture plan, material plan, placement, render prompt, shot plan, spz
+        "schema", // scenario/core/schema
+        "blender", // scenario/blender bpy glue: operators, props, apply_*, handlers, pump, registry, runtime, prefs
+        "ui", // panels, params_ui, popover, model picker, prompt tools, icons, docs/UI_STYLE.md
+        "composer", // scenario/blender/composer and scenario/core/ui/composer_layout.py
+        "mcp", // scenario/mcp and scenario/blender/mcp_service.py
+        "tests", // test harness only; a test for a product area keeps the product scope
+        "tools", // tools/ and the Makefile
+        "docs", // README.md, docs/, the user guide source
+        "ci", // .github/workflows, rulesets, hooks
+        "deps", // pins: Blender versions in CI, action versions
+        "release", // release-please config and manifest, version fields, CHANGELOG plumbing
+        "agents", // AGENTS.md, CLAUDE.md, .claude/
+        "repo", // LICENSE, CODE_OF_CONDUCT, SECURITY, templates, CODEOWNERS
+      ],
+    ],
+    "no-em-dash": [2, "always"],
+  },
+};
+
+export default config;


### PR DESCRIPTION
## What and why

Every change reaches `main` by a squash-merged pull request whose title becomes the commit header, and release-please classifies changes from that header. Nothing checked a PR title or a commit message until now.

- `commitlint.config.ts`: single source of truth. Types from `@commitlint/config-conventional`, header at most 120 characters, body and footer line limits off, `subject-case` off, `scope-empty` a warning (the release PR is `chore: release X.Y.Z`), the seventeen-scope list from D11, and a `no-em-dash` rule over the raw message.
- `.github/workflows/pr-name.yml`: job `pr-title` lints the PR title on opened, edited, reopened and synchronize. The title goes through an environment variable and is never interpolated into the script.
- `.github/workflows/commitlint.yml`: job `commits` lints the commits the PR adds on top of its base branch (advisory, never a required check).
- Node stays out of the checkout: no `package.json`; CI installs commitlint ad hoc pinned to major 21; `node_modules/` and `package-lock.json` are ignored.
- README: how to run the same check locally.

Differs from #34 as filed, by maintainer decision: the config is TypeScript instead of `.mjs`; the two jobs live in two workflow files; the `commits` job installs commitlint like the title job instead of using wagoid/commitlint-github-action, which only loads `.mjs` configs.

Closes #34

## Validation

- Twelve probe messages behave as #34 specifies: a valid `fix(blender)` header, `chore: release 0.9.10` (one `scope-empty` warning, exit 0), a `Merge a into b` line and a 150-character `Co-Authored-By` trailer all pass; `feat(prefs): x` (`scope-enum`), `0.9.9: fix Blockout`, a 123-character header, and an em dash in the header or the body all fail.
- `tsc --noEmit --strict` passes on `commitlint.config.ts`; `commitlint --from main --to HEAD` passes on this branch.
- Both workflow files parse, contain no `secrets.` reference and interpolate no event data into `run:`. No added file contains an em dash. `make test`: 219 passed.
- The `pr-title` and `commits` checks on this PR are the live test; #45 makes `pr-title` required once it has reported.

## Authorship

A human reviewed the complete diff before this PR was submitted. Authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds CI linting and docs only; no runtime or application code changes, with deliberate hardening for fork PR titles in the workflow scripts.
> 
> **Overview**
> Adds **Conventional Commits enforcement** for squash-merge workflows: a new `commitlint.config.ts` is the shared ruleset (conventional types, 17 allowed scopes, 120-character headers, custom **no em dash** rule, relaxed body/footer limits).
> 
> **CI** gets two PR workflows that install commitlint on the runner only (no `package.json`): `pr-name.yml` job **`pr-title`** lints the PR title (intended as a required ruleset check); `commitlint.yml` job **`commits`** lints commits on the branch vs base (documented as advisory). Both pass untrusted strings (`PR_TITLE`, `BASE_REF`) via environment variables rather than shell interpolation.
> 
> **`.gitignore`** ignores `node_modules/` and `package-lock.json` for the documented local `npm install --no-save` workflow. **README** adds a section on title/message policy and how to run the same lint locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383777fb18ec07d015f2ed6f8a7c2b30c5fc0561. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->